### PR TITLE
Custom current and path

### DIFF
--- a/lib/jsonpath.js
+++ b/lib/jsonpath.js
@@ -35,6 +35,8 @@ function jsonPath(obj, expr, arg) {
       flatten: arg && arg.flatten || false,
       wrap: (arg && arg.hasOwnProperty('wrap')) ? arg.wrap : true,
       sandbox: (arg && arg.sandbox) ? arg.sandbox : {},
+      path: arg && arg.path || '@path',
+      current: arg && arg.current || '@',
       normalize: function(expr) {
          if (cache[expr]) return cache[expr];
          var subx = [];
@@ -130,13 +132,13 @@ function jsonPath(obj, expr, arg) {
       },
       eval: function(code, _v, _vname, path) {
          if (!$ || !_v) return false;
-         if (code.indexOf("@path") > -1) {
+         if (code.indexOf(P.path) > -1) {
             P.sandbox["_path"] = P.asPath(path.concat([_vname]));
-            code = code.replace(/@path/g, "_path");
+            code = code.replace(new RegExp(P.path,'g'), "_path");
          }
-         if (code.indexOf("@") > -1) {
+         if (code.indexOf(P.current) > -1) {
             P.sandbox["_v"] = _v;
-            code = code.replace(/@/g, "_v");
+            code = code.replace(new RegExp(P.current,'g'), "_v");
          }
          try {
              return vm.runInNewContext(code, P.sandbox);

--- a/test/test.custom.js
+++ b/test/test.custom.js
@@ -1,0 +1,63 @@
+var jsonpath = require("../").eval
+  , testCase = require('nodeunit').testCase
+
+// tests based on examples at http://goessner.net/articles/JsonPath/
+
+var json = {"store": {
+    "book": [
+      { "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      { "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      },
+      { "category": "fiction",
+        "author": "Herman Melville",
+        "title": "Moby Dick",
+        "isbn": "0-553-21311-3",
+        "price": 8.99
+      },
+      { "category": "fiction",
+        "author": "J. R. R. Tolkien",
+        "title": "The Lord of the Rings",
+        "isbn": "0-395-19395-8",
+        "price": 22.99
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 19.95
+    }
+  }
+};
+
+
+module.exports = testCase({
+
+
+    // ============================================================================
+    "custom current": function(test) {
+    // ============================================================================
+        test.expect(1);
+        var books = json.store.book;
+        var expected = [books[2], books[3]];
+        var result = jsonpath(json, "$..book[?(@current.isbn)]", {current: '@current'});
+        test.deepEqual(expected, result);
+
+        test.done();
+    },
+
+
+    "custom path": function (test) {
+        var expected = json.store.book[1];
+        var result = jsonpath(json, "$..[?(@mypath==\"$['store']['book'][1]\")]", {wrap: false, path: '@mypath'});
+        test.deepEqual(expected, result);
+        test.done();
+    }
+
+
+});


### PR DESCRIPTION
When using JSONPath to work with output from e.g. xml2json I have run into the problem that '@' is used within property names, but I can't reference such names inside a JSONPath filter because '@' is hard coded as the current object. By allowing custom current and path strings I can overcome the problem.   