### PR TITLE
Fix npm compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - 0.10
+  - 0.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
-  - 0.10
-  - 0.12
+  - 'iojs'
+  - '0.12'
+  - '0.10'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "main": "./lib/jsonpath",
     "dependencies": {},
     "devDependencies": {
-        "nodeunit": "*"
+        "nodeunit": "0.9.0"
     },
     "scripts": {"test": "./node_modules/.bin/nodeunit test"}
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "main": "./lib/jsonpath",
     "dependencies": {},
     "devDependencies": {
-        "nodeunit": "0.8.8"
+        "nodeunit": "0.9.0"
     },
     "scripts": {"test": "./node_modules/.bin/nodeunit test"}
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "devDependencies": {
         "nodeunit": "*"
     },
-    "scripts": {"test": "node_modules/nodeunit/bin/nodeunit test/test.*.js"}
+    "scripts": {"test": "./node_modules/.bin/nodeunit test"}
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "main": "./lib/jsonpath",
     "dependencies": {},
     "devDependencies": {
-        "nodeunit": "0.9.0"
+        "nodeunit": "0.8.8"
     },
     "scripts": {"test": "./node_modules/.bin/nodeunit test"}
 }


### PR DESCRIPTION
The npm test script couldn't run on recent node versions because the syntax has changed, see package.json.

This way the local module can run, but other issues came out after this fix: nodeunit compatibility. The original semver required the latest nodeunit version which had incompatible dependencies.

As you can see in the commit I tried to fix the dependencies by lowering the nodeunit version, but it just never worked. Currently if I'm not mistaken nodeunit is unable to work below 0.9.0 because:
- 0.8.8 is messed up by deep-equal
- 0.8.8 is messed up again because tap requires at least 0.8 from node.

In this pull I have set the nodeunit version to fixed 0.9.0, this way it might be more future proof.