### PR TITLE
Add license attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
             "email": "robert.krahn@gmail.com"
         }
     ],
+    "license": "MIT",
     "version": "0.11.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
> npm, the awesome source code package manager for JavaScript and stuff, recently updated its guidelines on license metadata in package.json files. The new guidelines ask maintainers to use the SPDX standard’s license expression syntax to show how their work is licensed in a machine-readable way. You will get a warning if you don’t.

> In most cases, that's as easy as setting your license property (not licenses, as for RubyGems) to MIT, ISC, BSD-2-Clause, Apache-2.0, or some other string on SPDX' official list. You can even Unlicense or WTFPL, you rebel, you.

>Who cares? Nobody cares! Until they have to do a license check. Then, thanks to how amazing npm is, you’re left staring down a bottomless well of node_modules directories you must search, manually, for LICENSE files and hints in README. But shouldn’t some lousy program do that kind of work for you? Of course! And it would sure help if the npm ecosystem offered good, clean metadata to chew on.

http://npm1k.org