### PR TITLE
fix: detect node on react-native environments

### DIFF
--- a/lib/jsonpath.js
+++ b/lib/jsonpath.js
@@ -10,8 +10,9 @@ var module;
 (function (glbl, require) {'use strict';
 
 // Make sure to know if we are in real node or not (the `require` variable
-// could actually be require.js, for example.
-var isNode = module && !!module.exports;
+// could actually be require.js, for example). Will also check if we are
+// in react-native
+var isNode = module && !!module.exports && !(typeof navigator !== 'undefined' && navigator.product === 'ReactNative');
 
 var allowedResultTypes = ['value', 'path', 'pointer', 'parent', 'parentProperty', 'all'];
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "engines": {
     "node": ">=0.8"
   },
+  "react-native": {
+    "vm": false
+  },
   "devDependencies": {
     "eslint": "^1.10.3",
     "eslint-config-standard": "^4.4.0",


### PR DESCRIPTION
This PR will fix JSONPath plus for react-native.

Currently it will fail since `vm` is not available in react-native. When bundling JavaScript for react-native it will try to find `vm` without success (see change in `package.json`).

During runtime it will fail since detecting of node will also be true in react-native (see change in `lib/jsonpath.js`)

Take care,

Simon