### PR TITLE
Add explicit 'any' to evaluate() declaration

### DIFF
--- a/src/jsonpath.d.ts
+++ b/src/jsonpath.d.ts
@@ -181,13 +181,13 @@ declare module 'jsonpath-plus' {
         json: JSONPathOptions['json'],
         callback: JSONPathOptions['callback'],
         otherTypeCallback: JSONPathOptions['otherTypeCallback']
-    )
+    ): any
     evaluate(options: {
         path: JSONPathOptions['path'],
         json: JSONPathOptions['json'],
         callback: JSONPathOptions['callback'],
         otherTypeCallback: JSONPathOptions['otherTypeCallback']
-    })
+    }): any
   }
 
   type JSONPathType = JSONPathCallable & JSONPathClass


### PR DESCRIPTION
Without this, typescript will complain when used with '--noImplicitAny' option:
```
> tsc
node_modules/jsonpath-plus/src/jsonpath.d.ts:179:5 - error TS7010: 'evaluate', which lacks return-type annotation, implicitly has an 'any' return type.
179     evaluate(
        ~~~~~~~~
node_modules/jsonpath-plus/src/jsonpath.d.ts:185:5 - error TS7010: 'evaluate', which lacks return-type annotation, implicitly has an 'any' return type.
185     evaluate(options: {
        ~~~~~~~~
Found 2 errors.
```