### PR TITLE
Fixed typescript typing for sandbox

### DIFF
--- a/src/jsonpath.d.ts
+++ b/src/jsonpath.d.ts
@@ -54,7 +54,7 @@ declare module 'jsonpath-plus' {
      * (Note that the current path and value will also be available to those
      *   expressions; see the Syntax section for details.)
      */
-    sandbox?: Map<string, any>
+    sandbox?: {}
     /**
      * Whether or not to wrap the results in an array.
      *


### PR DESCRIPTION
I was using jsonpath plus in my typescript app, and noticed that the sandbox has the wrong typing. This will result in a compilation error in typescript, and makes using the sandbox setting impossible.

Could you release this asap? Otherwise using the sandbox settings with typescript is not possible.